### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release to Maven Central
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/ahauschulte/jtco/security/code-scanning/1](https://github.com/ahauschulte/jtco/security/code-scanning/1)

To fix the problem, add a `permissions` block with least-privilege settings to the workflow. Based on common Maven Central release workflows, only `contents: read` permission is typically required unless actions like releasing or uploading are performed through GitHub APIs. Place the `permissions` block either at the workflow root (after the `name:` and before `on:`) to apply it globally, or within the job definition (recommended for single-job workflows for clarity). Here, adding it at the workflow root is best:

Edit `.github/workflows/release.yml` to insert the following lines after `name: Release to Maven Central`:
```
permissions:
  contents: read
```
No imports or other definitions are needed, as it's a YAML metadata change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
